### PR TITLE
Provenance Resource Added...

### DIFF
--- a/Graphir.API/Extensions/Startup.Services.cs
+++ b/Graphir.API/Extensions/Startup.Services.cs
@@ -17,8 +17,8 @@ public static class StartupServices
 
         services.AddScoped<PatientMutation>();
         services.AddScoped<PractitionerMutation>();
-        
-        services.AddScoped<DataLoaderFactory>();        
+
+        services.AddScoped<DataLoaderFactory>();
     }
 
 
@@ -55,6 +55,7 @@ public static class StartupServices
             .AddDetectedIssue()
             .AddServiceRequest()
             .AddSpecimen()
+            .ModifyOptions(opt => opt.StrictValidation = true)
             .ModifyRequestOptions(opt => opt.IncludeExceptionDetails = true) //Remove this line in Production
             ;
     }

--- a/Graphir.API/Schema/MedicationAdministrationType.cs
+++ b/Graphir.API/Schema/MedicationAdministrationType.cs
@@ -1,4 +1,5 @@
 ﻿using Hl7.Fhir.Model;
+
 using HotChocolate.Types;
 
 namespace Graphir.API.Schema;
@@ -24,30 +25,21 @@ public class MedicationAdministrationType : ObjectType<MedicationAdministration>
             .Resolve(context =>
             {
                 var parent = context.Parent<MedicationAdministration>();
-                if (parent.Medication is null)
-                    return null;
-
-                if (parent.Medication.TypeName == "CodeableConcept")
-                {
-                    return new CodeableReference
+                return parent.Medication is null
+                    ? null
+                    : parent.Medication.TypeName switch
                     {
-                        Concept = (CodeableConcept)parent.Medication
+                        "CodeableConcept" => new CodeableReference { Concept = (CodeableConcept)parent.Medication },
+                        "Reference" => new CodeableReference { Reference = (ResourceReference)parent.Medication },
+                        _ => null
                     };
-                }
-                if (parent.Medication.TypeName == "Reference")
-                {
-                    return new CodeableReference
-                    {
-                        Reference = (ResourceReference)parent.Medication
-                    };
-                }
-                return null;
             });
 
         descriptor.Field(x => x.Subject).Type<ResourceReferenceType<MedicationAdministrationSubjectReferenceType>>();
         descriptor.Field(x => x.Request).Type<ResourceReferenceType<MedicationAdministrationRequestReferenceType>>();
         descriptor.Field(x => x.Device).Type<ResourceReferenceType<DeviceReferenceType>>();
-        descriptor.Field(x => x.EventHistory).Type<ListType<ResourceReferenceType<MedicationAdministrationEventHistoryReferenceType>>>();
+        descriptor.Field(x => x.EventHistory)
+            .Type<ListType<ResourceReferenceType<MedicationAdministrationEventHistoryReferenceType>>>();
 
         descriptor.Field("effectivePeriod").Type<PeriodType>().Resolve(context =>
         {
@@ -64,7 +56,6 @@ public class MedicationAdministrationType : ObjectType<MedicationAdministration>
                 : null;
         });
     }
-    
 }
 
 public class MedicationAdministrationPerformerComponentType : ObjectType<MedicationAdministration.PerformerComponent>
@@ -97,16 +88,16 @@ public class MedicationAdministrationDosageType : ObjectType<MedicationAdministr
         {
             var parent = r.Parent<MedicationAdministration.DosageComponent>();
             return parent.Rate is not null && parent.Rate.TypeName == "Ratio"
-            ? (Ratio)parent.Rate
-            : null;
+                ? (Ratio)parent.Rate
+                : null;
         });
 
         descriptor.Field("rateQuantity").Type<QuantityType>().Resolve(r =>
         {
             var parent = r.Parent<MedicationAdministration.DosageComponent>();
             return parent.Rate is not null && parent.Rate.TypeName == "Quantity"
-            ? (Quantity)parent.Rate
-            : null;
+                ? (Quantity)parent.Rate
+                : null;
         });
     }
 }

--- a/Graphir.API/Schema/MedicationType.cs
+++ b/Graphir.API/Schema/MedicationType.cs
@@ -50,25 +50,15 @@ public class MedicationIngredientType : ObjectType<Medication.IngredientComponen
             .Resolve(context =>
             {
                 var parent = context.Parent<Medication.IngredientComponent>();
-                if (parent.Item is null)
-                    return null;
-
-                if (parent.Item.TypeName == "CodeableConcept")
-                {
-                    return new CodeableReference
+                return parent.Item is null
+                    ? null
+                    : parent.Item.TypeName switch
                     {
-                        Concept = (CodeableConcept)parent.Item
+                        "CodeableConcept" => new CodeableReference { Concept = (CodeableConcept)parent.Item },
+                        "Reference" => new CodeableReference { Reference = (ResourceReference)parent.Item },
+                        _ => null
                     };
-                }
-                if (parent.Item.TypeName == "Reference")
-                {
-                    return new CodeableReference
-                    {
-                        Reference = (ResourceReference)parent.Item
-                    };
-                }
-                return null;
-            }); ;
+            });
         descriptor.Field(x => x.IsActive);
         descriptor.Field(x => x.Strength);
     }

--- a/Graphir.API/Schema/ObjectTypes.cs
+++ b/Graphir.API/Schema/ObjectTypes.cs
@@ -76,7 +76,10 @@ public class FhirStringType : ObjectType<FhirString>
     protected override void Configure(IObjectTypeDescriptor<FhirString> descriptor)
     {
         descriptor.BindFieldsExplicitly();
-        descriptor.Field(x => x.Value).Type<NonNullType<StringType>>();
+        
+        descriptor.Field(x => x.Value);
+        descriptor.Field(x => x.Extension);
+        descriptor.Field(x => x.TypeName);
     }
 }
 

--- a/Graphir.API/Schema/ProvenanceType.cs
+++ b/Graphir.API/Schema/ProvenanceType.cs
@@ -1,5 +1,4 @@
-﻿using Hl7.Fhir.ElementModel.Types;
-using Hl7.Fhir.Model;
+﻿using Hl7.Fhir.Model;
 
 using HotChocolate.Types;
 
@@ -9,7 +8,6 @@ namespace Graphir.API.Schema;
 
 public class ProvenanceType : ObjectType<Provenance>
 {
-    // TODO: finish Provenance
     protected override void Configure(IObjectTypeDescriptor<Provenance> descriptor)
     {
         descriptor.BindFieldsExplicitly();
@@ -17,14 +15,10 @@ public class ProvenanceType : ObjectType<Provenance>
         descriptor.Field(p => p.Id);
         descriptor.Field(p => p.Meta);
         descriptor.Field(p => p.Activity);
-         /*TODO: Resolve if this is a Period or a DateTime
-         descriptor.Field(p => p.Occurred);*/
-         
-
+        // descriptor.Field(p => p.Occurred); TODO: Resolve based on type Period or a DateTime
         descriptor.Field(p => p.Reason);
         descriptor.Field(p => p.Recorded);
         descriptor.Field(p => p.Signature).Type<ListType<SignatureType>>();
-
         descriptor.Field(p => p.Text);
         descriptor.Field(p => p.Policy);
         descriptor.Field(p => p.Language);
@@ -37,10 +31,9 @@ public class ProvenanceType : ObjectType<Provenance>
         descriptor.Field(p => p.PolicyElement);
         descriptor.Field(p => p.RecordedElement).Type<InstantType>();
         descriptor.Field(p => p.ResourceBase);
-
         descriptor.Field(p => p.Location).Type<ResourceReferenceType<ProvenanceLocationReferenceType>>();
         descriptor.Field(p => p.Entity).Type<ListType<ProvenanceEntityComponentType>>();
-        descriptor.Field(p => p.Agent).Type<ListType<ProvenanceAgentComponentType>>();
+        descriptor.Field(p => p.Agent).Type<ListType<AgentComponentType>>();
         descriptor.Field(p => p.Target).Type<ListType<ResourceReferenceType<ProvenanceTargetReferenceType>>>();
     }
 }
@@ -61,7 +54,11 @@ public class CodeType : ObjectType<Code>
     protected override void Configure(IObjectTypeDescriptor<Code> descriptor)
     {
         descriptor.BindFieldsExplicitly();
+        
         descriptor.Field(p => p.Value);
+        descriptor.Field(p => p.Display);
+        descriptor.Field(p => p.System);
+        descriptor.Field(p => p.Version);
     }
 }
 
@@ -102,28 +99,26 @@ public class ProvenanceEntityComponentType : ObjectType<Provenance.EntityCompone
         descriptor.BindFieldsExplicitly();
 
         descriptor.Field(p => p.Role);
-        descriptor.Field(p => p.Agent)
-            .Type<ListType<ProvenanceAgentComponentType>>();
+        descriptor.Field(p => p.Agent).Type<ListType<AgentComponentType>>();
         descriptor.Field(p => p.Extension);
         descriptor.Field(p => p.ModifierExtension);
-        // Same issue as parent field Target
-        descriptor.Field(p => p.What).Type<ResourceReferenceType<IdentityOfEntityReferenceType>>(); 
+        descriptor.Field(p => p.What).Type<ResourceReferenceType<WhatReferenceType>>();
         descriptor.Field(p => p.RoleElement).Type<StringType>(); //Must specify as StringType
         descriptor.Field(p => p.ElementId);
     }
 }
 
-public class IdentityOfEntityReferenceType : UnionType
+public class WhatReferenceType : UnionType
 {
     protected override void Configure(IUnionTypeDescriptor descriptor)
     {
         descriptor.Name("IdentityOfEntityReference");
-        
+
         descriptor.Type<ResourceType>();
     }
 }
 
-public class ProvenanceAgentComponentType : ObjectType<Provenance.AgentComponent>
+public class AgentComponentType : ObjectType<Provenance.AgentComponent>
 {
     protected override void Configure(IObjectTypeDescriptor<Provenance.AgentComponent> descriptor)
     {
@@ -145,7 +140,8 @@ public class OnBehalfOfReferenceType : UnionType
     protected override void Configure(IUnionTypeDescriptor descriptor)
     {
         descriptor.Name("OnBehalfOfReference");
-        descriptor.Description("Who the agent is representing? Reference(Practitioner | PractitionerRole | RelatedPerson | Patient | Device | Organization)");
+        descriptor.Description(@"Who the agent is representing? Reference(Practitioner | PractitionerRole | RelatedPerson | Patient | Device | Organization)");
+
         descriptor.Type<PractitionerType>();
         descriptor.Type<PractitionerRoleType>();
         descriptor.Type<RelatedPersonType>();
@@ -160,8 +156,8 @@ public class ProvenanceAgentWhoParticipatedReferenceType : UnionType
     protected override void Configure(IUnionTypeDescriptor descriptor)
     {
         descriptor.Name("WhoParticipatedReference");
-        descriptor.Description(
-            "Who participated? Reference(Practitioner | PractitionerRole | RelatedPerson | Patient | Device | Organization)");
+        descriptor.Description(@"Who participated? Reference(Practitioner | PractitionerRole | RelatedPerson | Patient | Device | Organization)");
+
         descriptor.Type<PractitionerType>();
         descriptor.Type<PractitionerRoleType>();
         descriptor.Type<RelatedPersonType>();
@@ -176,7 +172,7 @@ public class ProvenanceTargetReferenceType : UnionType
     protected override void Configure(IUnionTypeDescriptor descriptor)
     {
         descriptor.Name("ProvenanceTargetReference");
-        descriptor.Description("Target Reference(s) (usually version specific) Reference(Any)");
+
         descriptor.Type<ResourceType>();
     }
 }
@@ -187,6 +183,7 @@ public class ProvenanceLocationReferenceType : UnionType
     {
         descriptor.Name("ProvenanceLocation");
         descriptor.Description("Where the activity occurred, if relevant");
+
         descriptor.Type<LocationType>();
     }
 }

--- a/Graphir.API/Schema/ProvenanceType.cs
+++ b/Graphir.API/Schema/ProvenanceType.cs
@@ -1,5 +1,9 @@
-﻿using Hl7.Fhir.Model;
+﻿using Hl7.Fhir.ElementModel.Types;
+using Hl7.Fhir.Model;
+
 using HotChocolate.Types;
+
+using Code = Hl7.Fhir.ElementModel.Types.Code;
 
 namespace Graphir.API.Schema;
 
@@ -11,5 +15,178 @@ public class ProvenanceType : ObjectType<Provenance>
         descriptor.BindFieldsExplicitly();
 
         descriptor.Field(p => p.Id);
+        descriptor.Field(p => p.Meta);
+        descriptor.Field(p => p.Activity);
+         /*TODO: Resolve if this is a Period or a DateTime
+         descriptor.Field(p => p.Occurred);*/
+         
+
+        descriptor.Field(p => p.Reason);
+        descriptor.Field(p => p.Recorded);
+        descriptor.Field(p => p.Signature).Type<ListType<SignatureType>>();
+
+        descriptor.Field(p => p.Text);
+        descriptor.Field(p => p.Policy);
+        descriptor.Field(p => p.Language);
+        descriptor.Field(p => p.ImplicitRules);
+        descriptor.Field(p => p.Extension);
+        descriptor.Field(p => p.ModifierExtension);
+        descriptor.Field(p => p.Contained);
+        descriptor.Field(p => p.LanguageElement).Type<CodeType>();
+        descriptor.Field(p => p.ImplicitRulesElement).Type<FhirUriType>();
+        descriptor.Field(p => p.PolicyElement);
+        descriptor.Field(p => p.RecordedElement).Type<InstantType>();
+        descriptor.Field(p => p.ResourceBase);
+
+        descriptor.Field(p => p.Location).Type<ResourceReferenceType<ProvenanceLocationReferenceType>>();
+        descriptor.Field(p => p.Entity).Type<ListType<ProvenanceEntityComponentType>>();
+        descriptor.Field(p => p.Agent).Type<ListType<ProvenanceAgentComponentType>>();
+        descriptor.Field(p => p.Target).Type<ListType<ResourceReferenceType<ProvenanceTargetReferenceType>>>();
+    }
+}
+
+public class InstantType : ObjectType<Instant>
+{
+    protected override void Configure(IObjectTypeDescriptor<Instant> descriptor)
+    {
+        descriptor.BindFieldsExplicitly();
+
+        descriptor.Field(p => p.Value);
+        descriptor.Field(p => p.Extension);
+    }
+}
+
+public class CodeType : ObjectType<Code>
+{
+    protected override void Configure(IObjectTypeDescriptor<Code> descriptor)
+    {
+        descriptor.BindFieldsExplicitly();
+        descriptor.Field(p => p.Value);
+    }
+}
+
+public class FhirUriType : ObjectType<FhirUri>
+{
+    protected override void Configure(IObjectTypeDescriptor<FhirUri> descriptor)
+    {
+        descriptor.BindFieldsExplicitly();
+
+        descriptor.Field(p => p.Value);
+        descriptor.Field(p => p.Extension);
+    }
+}
+
+public class SignatureType : ObjectType<Signature>
+{
+    protected override void Configure(IObjectTypeDescriptor<Signature> descriptor)
+    {
+        descriptor.BindFieldsExplicitly();
+
+        descriptor.Field(p => p.Type);
+        descriptor.Field(p => p.When);
+        descriptor.Field(p => p.Who);
+        descriptor.Field(p => p.OnBehalfOf);
+        descriptor.Field(p => p.TargetFormat);
+        descriptor.Field(p => p.SigFormat);
+        descriptor.Field(p => p.Data);
+        descriptor.Field(p => p.Extension);
+        descriptor.Field(p => p.TypeName);
+        descriptor.Field(p => p.ElementId);
+    }
+}
+
+public class ProvenanceEntityComponentType : ObjectType<Provenance.EntityComponent>
+{
+    protected override void Configure(IObjectTypeDescriptor<Provenance.EntityComponent> descriptor)
+    {
+        descriptor.BindFieldsExplicitly();
+
+        descriptor.Field(p => p.Role);
+        descriptor.Field(p => p.Agent)
+            .Type<ListType<ProvenanceAgentComponentType>>();
+        descriptor.Field(p => p.Extension);
+        descriptor.Field(p => p.ModifierExtension);
+        // Same issue as parent field Target
+        descriptor.Field(p => p.What).Type<ResourceReferenceType<IdentityOfEntityReferenceType>>(); 
+        descriptor.Field(p => p.RoleElement).Type<StringType>(); //Must specify as StringType
+        descriptor.Field(p => p.ElementId);
+    }
+}
+
+public class IdentityOfEntityReferenceType : UnionType
+{
+    protected override void Configure(IUnionTypeDescriptor descriptor)
+    {
+        descriptor.Name("IdentityOfEntityReference");
+        
+        descriptor.Type<ResourceType>();
+    }
+}
+
+public class ProvenanceAgentComponentType : ObjectType<Provenance.AgentComponent>
+{
+    protected override void Configure(IObjectTypeDescriptor<Provenance.AgentComponent> descriptor)
+    {
+        descriptor.BindFieldsExplicitly();
+
+        descriptor.Field(p => p.Type);
+        descriptor.Field(p => p.Role);
+        descriptor.Field(p => p.Who)
+            .Type<ResourceReferenceType<ProvenanceAgentWhoParticipatedReferenceType>>();
+        descriptor.Field(p => p.OnBehalfOf)
+            .Type<ResourceReferenceType<OnBehalfOfReferenceType>>();
+        descriptor.Field(p => p.Extension);
+        descriptor.Field(p => p.ModifierExtension);
+    }
+}
+
+public class OnBehalfOfReferenceType : UnionType
+{
+    protected override void Configure(IUnionTypeDescriptor descriptor)
+    {
+        descriptor.Name("OnBehalfOfReference");
+        descriptor.Description("Who the agent is representing? Reference(Practitioner | PractitionerRole | RelatedPerson | Patient | Device | Organization)");
+        descriptor.Type<PractitionerType>();
+        descriptor.Type<PractitionerRoleType>();
+        descriptor.Type<RelatedPersonType>();
+        descriptor.Type<PatientType>();
+        descriptor.Type<DeviceType>();
+        descriptor.Type<OrganizationType>();
+    }
+}
+
+public class ProvenanceAgentWhoParticipatedReferenceType : UnionType
+{
+    protected override void Configure(IUnionTypeDescriptor descriptor)
+    {
+        descriptor.Name("WhoParticipatedReference");
+        descriptor.Description(
+            "Who participated? Reference(Practitioner | PractitionerRole | RelatedPerson | Patient | Device | Organization)");
+        descriptor.Type<PractitionerType>();
+        descriptor.Type<PractitionerRoleType>();
+        descriptor.Type<RelatedPersonType>();
+        descriptor.Type<PatientType>();
+        descriptor.Type<DeviceType>();
+        descriptor.Type<OrganizationType>();
+    }
+}
+
+public class ProvenanceTargetReferenceType : UnionType
+{
+    protected override void Configure(IUnionTypeDescriptor descriptor)
+    {
+        descriptor.Name("ProvenanceTargetReference");
+        descriptor.Description("Target Reference(s) (usually version specific) Reference(Any)");
+        descriptor.Type<ResourceType>();
+    }
+}
+
+public class ProvenanceLocationReferenceType : UnionType
+{
+    protected override void Configure(IUnionTypeDescriptor descriptor)
+    {
+        descriptor.Name("ProvenanceLocation");
+        descriptor.Description("Where the activity occurred, if relevant");
+        descriptor.Type<LocationType>();
     }
 }


### PR DESCRIPTION
FhirStringType's Missing fields added

ModifiyOptions added in Startup.Services.cs which can be set as "false" if testing before schema resolvers are complete

Medication.TypeName if condition converted as switch expression to reduce the nesting and merge with pattern match in the return statement

MedicationType's Item field resolver code syntax improved with switch expression