### PR TITLE
Removed Duplicate ID field from AccountType.cs

### DIFF
--- a/Graphir.API/Schema/AccountType.cs
+++ b/Graphir.API/Schema/AccountType.cs
@@ -26,8 +26,6 @@ public class AccountType : ObjectType<Account>
         descriptor.Field(x => x.Owner).Type<ResourceReferenceType<OrganizationReferenceType>>();
         descriptor.Field(x => x.Description);
         descriptor.Field(x => x.Guarantor).Type<ListType<AccountGuarantorType>>();
-        descriptor.Field(x => x.Id);
-        descriptor.Field(x => x.Id);
     }
 
     private class AccountSubjectReferenceType : UnionType

--- a/Graphir.API/Schema/TaskType.cs
+++ b/Graphir.API/Schema/TaskType.cs
@@ -45,8 +45,8 @@ public class TaskType : ObjectType<Task>
         descriptor.Field(x => x.Note);
         descriptor.Field(x => x.RelevantHistory).Type<ListType<ResourceReferenceType<ProvenanceReferenceType>>>();
         descriptor.Field(x => x.Restriction).Type<TaskRestrictionType>();
-        descriptor.Field(x => x.Input).Type<TaskParameterType>();
-        descriptor.Field(x => x.Output).Type<TaskOutputType>();
+        descriptor.Field(x => x.Input).Type<ListType<TaskParameterType>>();
+        descriptor.Field(x => x.Output).Type<ListType<TaskOutputType>>();
     }
 
     private class TaskRequesterReferenceType : UnionType


### PR DESCRIPTION
Removed Duplicate ID field from AccountType.cs

TaskType fields input and output fields updated as ListType since they are representing List of Components